### PR TITLE
Move config to the separated library

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ Additional cmake flags are (e.g. to enable `FEATURE` use `-DFEATURE=ON`):
 ```
 .
 └── zephir
-    ├── commands
     ├── config
-    │   └── filesystem
+    │   ├── commands
+    │   │   └── CLI11
+    │   ├── filesystem
     │   └── yaml-cpp
     └── filesystem
 ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,26 +8,11 @@
 # Zephir libraries
 add_subdirectory(commands)
 add_subdirectory(filesystem)
-
-set(YAMLCPP_STATIC_LIBRARY ON)
-find_package(YAMLCPP REQUIRED)
-add_library(config STATIC config.cpp)
-
-target_include_directories(config PUBLIC ${YAMLCPP_INCLUDE_DIR}
-                                         ${CMAKE_SOURCE_DIR}/include)
-
-target_link_libraries(
-  config
-  PUBLIC filesystem
-  PRIVATE ${YAMLCPP_LIBRARY})
-
-if(CODE_COVERAGE)
-  target_code_coverage(config AUTO ALL)
-endif()
+add_subdirectory(config)
 
 # Main
 add_executable(zephir main.cpp)
-target_link_libraries(zephir PRIVATE config commands)
+target_link_libraries(zephir PRIVATE config)
 
 if(CODE_COVERAGE)
   target_code_coverage(zephir AUTO ALL)

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,0 +1,35 @@
+# This file is part of the Zephir.
+#
+# (c) Zephir Team <team@zephir-lang.com>
+#
+# For the full copyright and license information, please view the LICENSE file
+# that was distributed with this source code.
+
+set(YAMLCPP_STATIC_LIBRARY ON)
+find_package(YAMLCPP REQUIRED)
+
+# Add definition for config library.
+add_library(config STATIC config.cpp)
+
+target_include_directories(
+  config PUBLIC ${YAMLCPP_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/src
+                ${CMAKE_SOURCE_DIR}/include)
+
+target_link_libraries(
+  config
+  # PUBLIC filesystem
+  PRIVATE filesystem commands ${YAMLCPP_LIBRARY})
+
+if(CODE_COVERAGE)
+  target_code_coverage(config AUTO ALL)
+endif()
+
+# CMakeLists.txt ends here
+
+# cmake-format: off
+# Local Variables:
+# mode: cmake
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:
+# cmake-format: on

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -5,7 +5,7 @@
 // For the full copyright and license information, please view
 // the LICENSE file that was distributed with this source code.
 
-#include "zephir/config.hpp"
+#include "config.hpp"
 
 #include <yaml-cpp/yaml.h>
 
@@ -35,7 +35,8 @@ int parse_yaml_config(zephir::Config *config, const std::string &config_file) {
 }
 }  // namespace
 
-zephir::Config zephir::load_config(int argc, char **argv, std::string config_file) {
+zephir::Config zephir::load_config(int argc, char **argv,
+                                   std::string config_file) {
   zephir::Config config;
   auto retval = zephir::commands::optparse(argc, argv);
   if (retval == EXIT_HELP) {

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -5,8 +5,8 @@
 // For the full copyright and license information, please view
 // the LICENSE file that was distributed with this source code.
 
-#ifndef ZEPHIR_CONFIG_HPP_
-#define ZEPHIR_CONFIG_HPP_
+#ifndef ZEPHIR_CONFIG_CONFIG_HPP_
+#define ZEPHIR_CONFIG_CONFIG_HPP_
 
 #include <map>
 #include <set>
@@ -108,4 +108,4 @@ struct Config {
 Config load_config(int argc, char **argv, std::string config_file);
 }  // namespace zephir
 
-#endif  // ZEPHIR_CONFIG_HPP_
+#endif  // ZEPHIR_CONFIG_CONFIG_HPP_

--- a/src/filesystem/filesystem.cpp
+++ b/src/filesystem/filesystem.cpp
@@ -8,6 +8,7 @@
 #include "filesystem.hpp"
 
 #include <unistd.h>
+
 #include <cerrno>
 #include <climits>
 #include <sstream>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-#include "zephir/config.hpp"
+#include "config/config.hpp"
 #include "filesystem/filesystem.hpp"
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
##### Library dependencies graph

```
.
└── zephir
    ├── config
    │   ├── commands
    │   │   └── CLI11
    │   ├── filesystem
    │   └── yaml-cpp
    └── filesystem
```