### PR TITLE
Dynamically link libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Zephir licensed under the MIT License. See the [LICENSE][license link] file for 
 
 [actions link]: https://github.com/sergeyklay/cpp-zephir/actions
 [actions-badge]: https://github.com/sergeyklay/cpp-zephir/workflows/build/badge.svg
-[coverage badge]: https://codecov.io/gh/klay/cpp-zephir/branch/master/graph/badge.svg?token=l1Oy2k15VP
+[coverage badge]: https://codecov.io/gh/sergeyklay/cpp-zephir/branch/master/graph/badge.svg?token=l1Oy2k15VP
 [coverage link]: https://codecov.io/gh/sergeyklay/cpp-zephir
 [codacy badge]: https://api.codacy.com/project/badge/Grade/f261623a61494a38b383b399ae557b21
-[codacy link]:  https://www.codacy.com/app/sergeyklay/cpp-zephir?utm_source=github.com&utm_medium=referral&utm_content=CLIUtils/CLI11&utm_campaign=Badge_Grade
+[codacy link]:  https://www.codacy.com/app/klay/cpp-zephir?utm_source=github.com&utm_medium=referral&utm_content=CLIUtils/CLI11&utm_campaign=Badge_Grade
 [web site]: https://zephir-lang.com
 [documentation]: https://docs.zephir-lang.com
 [zephir logo]: https://assets.phalconphp.com/zephir/zephir_logo-105x36.svg

--- a/cmake/FindYAMLCPP.cmake
+++ b/cmake/FindYAMLCPP.cmake
@@ -7,15 +7,7 @@
 
 # A module to find yaml-cpp module.
 #
-# By default, the dynamic libraries of yaml-cpp will be found. To find the
-# static ones instead, you must set the YAMLCPP_STATIC_LIBRARY variable to TRUE
-# before calling find_package(YAMLCPP ...).
-#
-# Example:
-# ~~~
-# set(YAMLCPP_STATIC_LIBRARY TRUE)
-# find_package(YAMLCPP REQUIRED)
-# ~~~
+# By default, the dynamic libraries of yaml-cpp will be found.
 #
 # If yaml-cpp is not installed in a standard path, you can use the YAMLCPP_DIR
 # CMake variable to tell CMake where yaml-cpp is.
@@ -25,15 +17,6 @@
 # * YAMLCPP_FOUND:       If false, do not try to link to yaml-cpp
 # * YAMLCPP_LIBRARY:     Where to find yaml-cpp
 # * YAMLCPP_INCLUDE_DIR: Where to find yaml.h
-
-# Attempt to find static library first if this is set
-if(YAMLCPP_STATIC_LIBRARY)
-  if(UNIX)
-    set(YAMLCPP_STATIC libyaml-cpp.a)
-  else()
-    set(YAMLCPP_STATIC yaml-cpp.lib)
-  endif()
-endif()
 
 unset(YAMLCPP_INCLUDE_DIR CACHE)
 unset(YAMLCPP_LIBRARY CACHE)

--- a/src/commands/CMakeLists.txt
+++ b/src/commands/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Add definition for commands library.
 file(GLOB CMD_FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmd_*.cpp)
-add_library(commands STATIC commands.cpp formatter.cpp ${CMD_FILES})
+add_library(commands SHARED commands.cpp formatter.cpp ${CMD_FILES})
 
 target_include_directories(
   commands PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -5,11 +5,10 @@
 # For the full copyright and license information, please view the LICENSE file
 # that was distributed with this source code.
 
-set(YAMLCPP_STATIC_LIBRARY ON)
 find_package(YAMLCPP REQUIRED)
 
 # Add definition for config library.
-add_library(config STATIC config.cpp)
+add_library(config SHARED config.cpp)
 
 target_include_directories(
   config
@@ -18,7 +17,7 @@ target_include_directories(
           ${YAMLCPP_INCLUDE_DIR}
   PUBLIC ${CMAKE_SOURCE_DIR}/src)
 
-target_link_libraries(config PRIVATE ${YAMLCPP_LIBRARY} filesystem commands)
+target_link_libraries(config PUBLIC ${YAMLCPP_LIBRARY} filesystem commands)
 target_code_coverage(config AUTO ALL)
 
 # CMakeLists.txt ends here

--- a/src/filesystem/CMakeLists.txt
+++ b/src/filesystem/CMakeLists.txt
@@ -6,7 +6,7 @@
 # that was distributed with this source code.
 
 # Add definition for filesystem library.
-add_library(filesystem STATIC filesystem.cpp)
+add_library(filesystem SHARED filesystem.cpp)
 target_code_coverage(filesystem AUTO ALL)
 
 # CMakeLists.txt ends here

--- a/src/logger/CMakeLists.txt
+++ b/src/logger/CMakeLists.txt
@@ -8,7 +8,7 @@
 find_package(spdlog CONFIG REQUIRED)
 
 # Add definition for logger facade library.
-add_library(logger STATIC facade.cpp)
+add_library(logger SHARED facade.cpp)
 
 target_include_directories(
   logger

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,7 +34,8 @@ target_include_directories(
           $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
           ${CMAKE_SOURCE_DIR}/src/config)
 
-target_link_libraries(config_test PRIVATE gtest config)
+target_link_libraries(config_test PRIVATE gtest)
+target_link_libraries(config_test PUBLIC config)
 target_code_coverage(config_test AUTO ALL EXCLUDE ${COVERAGE_EXCLUDES})
 
 gtest_discover_tests(


### PR DESCRIPTION
- Dynamic library can be modified without a need to re-compile
- Reduce main executables size
- There is no need to compile all-in-one