### PR TITLE
Implement dumping config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = external/cmake-scripts
 	url = https://github.com/StableCoder/cmake-scripts.git
 	branch = master
+[submodule "tests/sharness"]
+	path = tests/sharness
+	url = https://github.com/chriscool/sharness.git
+	branch = master

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -17,4 +17,4 @@ target_include_directories(
 # Instruments the library
 target_code_coverage(config AUTO ALL)
 
-target_link_libraries(config PUBLIC CONAN_PKG::yaml-cpp stdc++fs filesystem)
+target_link_libraries(config PUBLIC CONAN_PKG::yaml-cpp filesystem)

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -17,4 +17,4 @@ target_include_directories(
 # Instruments the library
 target_code_coverage(config AUTO ALL)
 
-target_link_libraries(config PUBLIC CONAN_PKG::yaml-cpp filesystem)
+target_link_libraries(config PUBLIC CONAN_PKG::yaml-cpp stdc++fs filesystem)

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -7,39 +7,7 @@
 
 #include "config.hpp"
 
-#include <yaml-cpp/yaml.h>
-
-#include <memory>
-
 #include "../filesystem/filesystem.hpp"
-
-namespace {
-/**
- * @brief Populate project configuration.
- *
- * @param path Configuration file.
- * @return Shared pointer to the zephir::Config
- */
-zephir::ConfigPtr PopulateConfig(const std::string &path) {
-  auto config = std::make_shared<zephir::Config>();
-
-  if (!zephir::filesystem::Exists(path)) {
-    // Nothing to do if we unable to find config file at the disk.
-    return config;
-  }
-
-  // YAML::BadFile should normally never thrown here
-  // because we did check for file existence before.
-  try {
-    YAML::Node node = YAML::LoadFile(path);
-    YAML::convert<zephir::ConfigPtr>::decode(node, config);
-
-    return config;
-  } catch (YAML::ParserException &e) {
-    throw std::runtime_error("Config file is broken");
-  }
-}
-}  // namespace
 
 zephir::Config::Config()
     : ns_(),
@@ -50,7 +18,7 @@ zephir::Config::Config()
       backend_("ZendEngine3"),
       verbose_(false),
       silent_(false),
-      path_(".zephir"),
+      path_(""),
       changed_(false),
       requires_(),
       stubs_(),
@@ -60,6 +28,27 @@ zephir::Config::Config()
       extra_() {}
 
 zephir::Config::~Config() { DumpToFile(); }
+
+zephir::ConfigPtr zephir::Config::Load(const std::string &path) {
+  auto config = std::make_shared<zephir::Config>();
+  config->path_ = path;
+
+  if (!zephir::filesystem::Exists(config->path_)) {
+    // Nothing to do if we unable to find config file at the disk.
+    return config;
+  }
+
+  // YAML::BadFile should normally never thrown here
+  // because we did check for file existence before.
+  try {
+    YAML::Node node = YAML::LoadFile(config->path_);
+    YAML::convert<zephir::ConfigPtr>::decode(node, config);
+
+    return config;
+  } catch (YAML::ParserException &e) {
+    throw std::runtime_error("Config file is broken");
+  }
+}
 
 void zephir::Config::DumpToFile() {
   if (changed_ && !path_.empty() && !zephir::filesystem::Exists(path_)) {
@@ -73,7 +62,7 @@ bool zephir::Config::IsChanged() { return changed_; }
 
 zephir::ConfigPtr zephir::Config::Factory(std::vector<std::string> &options,
                                           const std::string &path) {
-  auto config = PopulateConfig(path);
+  auto config = zephir::Config::Load(path);
 
   if (!options.empty()) {
     // TODO(klay): Process config, use argv

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -7,8 +7,6 @@
 
 #include "config.hpp"
 
-#include <fstream>
-
 #include "../filesystem/filesystem.hpp"
 
 zephir::Config::Config()
@@ -29,8 +27,6 @@ zephir::Config::Config()
       optimizations_(),
       extra_() {}
 
-zephir::Config::~Config() { DumpToFile(); }
-
 zephir::ConfigPtr zephir::Config::Load(const std::string &path) {
   auto config = std::make_shared<zephir::Config>();
   config->path_ = path;
@@ -49,16 +45,6 @@ zephir::ConfigPtr zephir::Config::Load(const std::string &path) {
     return config;
   } catch (YAML::ParserException &e) {
     throw std::runtime_error("Config file is broken");
-  }
-}
-
-void zephir::Config::DumpToFile() {
-  if (changed_ && !path_.empty() && !zephir::filesystem::Exists(path_)) {
-    auto yaml = YAML::convert<zephir::ConfigPtr>::encode(shared_from_this());
-
-    std::ofstream file(path_);
-    file << yaml;
-    file.close();
   }
 }
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -12,8 +12,6 @@
 
 #include "../filesystem/filesystem.hpp"
 
-namespace fs = std::filesystem;
-
 zephir::Config::Config()
     : ns_(),
       name_(),
@@ -59,11 +57,9 @@ void zephir::Config::DumpToFile() {
   if (changed_ && !path_.empty() && !zephir::filesystem::Exists(path_)) {
     auto yaml = YAML::convert<zephir::ConfigPtr>::encode(shared_from_this());
 
-    fs::path path(path_);
-    std::ofstream ofs(path);
-
-    ofs << yaml;
-    ofs.close();
+    std::ofstream file(path_);
+    file << yaml;
+    file.close();
   }
 }
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -7,7 +7,6 @@
 
 #include "config.hpp"
 
-#include <filesystem>
 #include <fstream>
 
 #include "../filesystem/filesystem.hpp"

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -7,7 +7,12 @@
 
 #include "config.hpp"
 
+#include <filesystem>
+#include <fstream>
+
 #include "../filesystem/filesystem.hpp"
+
+namespace fs = std::filesystem;
 
 zephir::Config::Config()
     : ns_(),
@@ -52,9 +57,13 @@ zephir::ConfigPtr zephir::Config::Load(const std::string &path) {
 
 void zephir::Config::DumpToFile() {
   if (changed_ && !path_.empty() && !zephir::filesystem::Exists(path_)) {
-    // TODO(klay):
-    // 1. Convert container_ to yaml
-    // 2. Write yaml to path_
+    auto yaml = YAML::convert<zephir::ConfigPtr>::encode(shared_from_this());
+
+    fs::path path(path_);
+    std::ofstream ofs(path);
+
+    ofs << yaml;
+    ofs.close();
   }
 }
 

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -39,17 +39,12 @@ namespace zephir {
 /**
  * @brief Manages compiler global configuration.
  */
-class Config : public std::enable_shared_from_this<Config> {
+class Config {
  public:
   /**
    * @brief Config constructor.
    */
   Config();
-
-  /**
-   * @brief Config destructor.
-   */
-  ~Config();
 
   /**
    * @brief Load configuration from a file path.
@@ -58,11 +53,6 @@ class Config : public std::enable_shared_from_this<Config> {
    * @return A shared pointer to the zephir::Config
    */
   static zephir::ConfigPtr Load(const std::string &path);
-
-  /**
-   * @brief Writes the configuration if it has been changed.
-   */
-  void DumpToFile();
 
   /**
    * @brief Is config changed?

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -39,7 +39,7 @@ namespace zephir {
 /**
  * @brief Manages compiler global configuration.
  */
-class Config {
+class Config : public std::enable_shared_from_this<Config> {
  public:
   /**
    * @brief Config constructor.
@@ -50,6 +50,14 @@ class Config {
    * @brief Config destructor.
    */
   ~Config();
+
+  /**
+   * @brief Load configuration from a file path.
+   *
+   * @param path The path to the configuration file.
+   * @return A shared pointer to the zephir::Config
+   */
+  static zephir::ConfigPtr Load(const std::string &path);
 
   /**
    * @brief Writes the configuration if it has been changed.

--- a/src/config/yaml/config.cpp
+++ b/src/config/yaml/config.cpp
@@ -107,5 +107,6 @@ bool YAML::convert<zephir::ConfigPtr>::decode(const YAML::Node &node,
     cptr->extra_ = *e;
   }
 
+  cptr->changed_ = true;
   return true;
 }

--- a/src/console/application.cpp
+++ b/src/console/application.cpp
@@ -85,3 +85,18 @@ int zephir::console::Application::Run() {
 
   return 0;
 }
+
+zephir::console::Application::~Application() { DumpConfig(); }
+
+void zephir::console::Application::DumpConfig() {
+  if (config_ && config_->IsChanged() && !base_path_.empty()) {
+    auto config_file = base_path_ + "/.zephir";
+
+    if (!zephir::filesystem::Exists(config_file)) {
+      auto yaml = YAML::convert<zephir::ConfigPtr>::encode(config_);
+      std::ofstream file(config_file);
+      file << yaml;
+      file.close();
+    }
+  }
+}

--- a/src/console/application.cpp
+++ b/src/console/application.cpp
@@ -17,7 +17,7 @@ zephir::console::Application::Application(std::vector<std::string> args,
                                           std::string base_path)
     : args_(std::move(args)),
       base_path_(std::move(base_path)),
-      config_(zephir::Config::Factory(args_, base_path_ + "/.zephir.yml")),
+      config_(zephir::Config::Factory(args_, base_path_ + "/.zephir")),
       formatter_(std::make_shared<zephir::console::Formatter>()),
       app_(std::make_shared<CLI::App>()),
       help_(nullptr),

--- a/src/console/application.hpp
+++ b/src/console/application.hpp
@@ -19,9 +19,22 @@ namespace zephir::console {
 
 class Application {
  public:
+  /**
+   * @brief Application constructor.
+   */
   explicit Application(std::vector<std::string> args, std::string base_path);
   Application(const Application&) = delete;
-  ~Application() = default;
+
+  /**
+   * @brief Application destructor.
+   */
+  ~Application();
+
+  /**
+   * @brief Dumps the project configuration to the disk if it has been changed.
+   */
+  void DumpConfig();
+
   void AddCommand(commands::CommandPtr command);
   int Run();
   Application& operator=(const Application&) = delete;

--- a/src/filesystem/filesystem.cpp
+++ b/src/filesystem/filesystem.cpp
@@ -11,7 +11,7 @@
 
 #include <climits>
 
-bool zephir::filesystem::Exists(const std::string &name) {
+bool zephir::filesystem::Exists(const std::string &name) noexcept {
   return (access(name.c_str(), F_OK) != -1);
 }
 

--- a/src/filesystem/filesystem.hpp
+++ b/src/filesystem/filesystem.hpp
@@ -17,7 +17,7 @@ namespace zephir::filesystem {
  * @param name The location of the file
  * @return true on success, false otherwise
  */
-bool Exists(const std::string& name);
+bool Exists(const std::string& name) noexcept;
 
 /**
  * @brief Gets current working compiler path.

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+test-results/
+trash directory.*.sh/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,19 +59,16 @@ gtest_discover_tests(
   TEST_PREFIX zephir:
   PROPERTIES LABELS ConfigTest)
 
+if(NOT WIN32)
+  add_test(
+    NAME BlackboxTest
+    COMMAND make
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
+
 add_custom_target(
   check
   COMMAND ctest -j ${BUILD_JOBS} --output-on-failure
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   DEPENDS ${ZEPHIR_TESTS}
   COMMENT "Run all tests...")
-
-# cmake-format: off
-# TODO: sharness tests
-# if(NOT WIN32)
-#     add_test(
-#     NAME              BlackboxTest
-#     COMMAND           make
-#     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/sharness")
-# endif()
-# cmake-format: on

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,57 @@
+# This file is part of the Zephir.
+#
+# (c) Zephir Team <team@zephir-lang.com>
+#
+# For the full copyright and license information, please view
+# the LICENSE file that was distributed with this source code.
+
+# NOTE: run with TEST_VERBOSE=1 for verbose sharness tests.
+
+T = $(sort $(wildcard t[0-9][0-9][0-9][0-9]-*.sh))
+SHARNESSDIR = sharness
+SHARNESS = $(SHARNESSDIR)/sharness.sh
+AGGREGATE = $(SHARNESSDIR)/aggregate-results.sh
+
+PROJECTDIR=$(shell cd $(SHARNESSDIR)/../.. || exit 1; pwd)
+TESTSDIR=$(shell cd $(PROJECTDIR)/tests || exit 1; pwd)
+
+# TODO: Call "make all" to compile zephir in case of absence
+BINS = zephir
+
+.PHONY: all
+all: aggregate
+
+.PHONY: clean
+clean: clean-test-results
+	@echo "*** $@ ***"
+	@find $(TESTSDIR)/fixtures -name compile-errors.log -o -name compile.log -delete
+	@find $(TESTSDIR)/fixtures -name .zephir -type d -exec rm -rf {} +
+	@find $(TESTSDIR)/fixtures -name ext -type d -exec rm -rf {} +
+	@find $(TESTSDIR)/output -type f -not -name .gitignore -delete
+	@rm -rf "trash "directory.*
+
+.PHONY: clean-test-results
+clean-test-results:
+	@echo "*** $@ ***"
+	@rm -rf test-results
+
+.PHONY: $(T)
+$(T): clean-test-results deps
+	@echo "*** $@ ***"
+	./$@
+
+.PHONY: aggregate
+aggregate: clean-test-results $(T)
+	@echo "*** $@ ***"
+	ls test-results/t*-*.sh.*.counts | $(AGGREGATE)
+
+.PHONY: deps
+deps: $(TESTSDIR)/$(SHARNESSDIR)
+
+$(TESTSDIR)/$(SHARNESSDIR): git
+	@echo "*** checking $@ ***"
+	@cd "$(PROJECTDIR)" git submodule update --remote --merge
+
+git:
+	@echo "*** checking $@ ***"
+	@which git >/dev/null || (echo "Please install git!" && false)

--- a/tests/config/config.base.cpp
+++ b/tests/config/config.base.cpp
@@ -58,5 +58,5 @@ TEST_F(ConfigBaseTest, CorrectConfigFile) {
   auto file = tests_root + "/fixtures/phalcon-4x.yml";
   auto config = zephir::Config::Factory(argv, file).get();
 
-  EXPECT_FALSE(config->IsChanged());
+  EXPECT_TRUE(config->IsChanged());
 }

--- a/tests/config/config.decode.cpp
+++ b/tests/config/config.decode.cpp
@@ -108,3 +108,10 @@ TEST(ConfigTest, DecodeInvalid) {
 
   EXPECT_FALSE(YAML::convert<zephir::ConfigPtr>::decode(yaml["foo"], actual));
 }
+
+TEST(ConfigTest, DecodeEmptyMap) {
+  auto yaml = YAML::Node(YAML::NodeType::Map);
+  auto actual = std::make_shared<zephir::Config>();
+
+  EXPECT_TRUE(YAML::convert<zephir::ConfigPtr>::decode(yaml, actual));
+}

--- a/tests/output/.gitignore
+++ b/tests/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This file is part of the Zephir.
+#
+# (c) Zephir Team <team@zephir-lang.com>
+#
+# For the full copyright and license information, please view
+# the LICENSE file that was distributed with this source code.
+
+# set sharness verbosity. we set the env var directly as
+# it's too late to pass in --verbose, and --verbose is harder
+# to pass through in some cases.
+# shellcheck disable=SC2034
+test "$TEST_VERBOSE" = 1 && verbose=t
+
+PROJECTDIR=$(cd "$(dirname "$0")/../" || exit 1; pwd)
+TESTSDIR="$PROJECTDIR/tests"
+SHARNESS_TEST_SRCDIR="$TESTSDIR/sharness"
+SHARNESS_LIB="$SHARNESS_TEST_SRCDIR/sharness.sh"
+export PROJECTDIR TESTSDIR SHARNESS_TEST_SRCDIR SHARNESS_LIB
+
+# shellcheck source=lib/sharness/sharness.sh
+source "$SHARNESS_LIB" || {
+  echo >&2 "Cannot source: $SHARNESS_LIB"
+  echo >&2 "Please check Sharness installation."
+  exit 1
+}
+
+if test "$TEST_VERBOSE" = 1; then
+  (>&1 printf "# TEST_VERBOSE='%s'\n" "$TEST_VERBOSE")
+fi
+
+: "${ZEPHIR_BIN_DIR:=$PROJECTDIR/build/bin}"
+
+ZEPHIR_BIN="$ZEPHIR_BIN_DIR/zephir"
+FIXTURESDIR="$TESTSDIR/fixtures"
+OUTPUTDIR="$TESTSDIR/output"
+export FIXTURESDIR OUTPUTDIR ZEPHIR_BIN
+
+function zephirc() {
+  test "$TEST_VERBOSE" = 1 && (>&1 printf "# %s\\n" "$ZEPHIR_BIN $*")
+  eval "$ZEPHIR_BIN $*"
+}


### PR DESCRIPTION
- Move `PopulateConfig` -> `zephir::Config::Load`
- Add `sharness` tests support
- Move `zephir::Config::DumpToFile` -> `console::Application::DumpConfig`
- Implement `console::Application::DumpConfig`
- Mark config as changed after load yaml